### PR TITLE
Allow to open external links

### DIFF
--- a/app/src/main/java/us/spotco/maps/MainActivity.java
+++ b/app/src/main/java/us/spotco/maps/MainActivity.java
@@ -22,6 +22,7 @@ import android.app.AlertDialog;
 import android.content.ActivityNotFoundException;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.location.LocationListener;
@@ -243,6 +244,21 @@ public class MainActivity extends Activity {
                 }
                 if (!allowed) {
                     Log.d(TAG, "[shouldOverrideUrlLoading][NOT ON ALLOWLIST] Blocked access to " + request.getUrl().getHost());
+                    if (request.getUrl().toString().startsWith("https://")) {
+                        (new AlertDialog.Builder(context)
+                            .setTitle(R.string.title_open_link)
+                            .setMessage(context.getString(R.string.text_open_link, request.getUrl().toString()))
+                            .setNegativeButton(android.R.string.cancel, null)
+                            .setPositiveButton(
+                                android.R.string.ok,
+                                (dialogInterface, i) ->
+                                    startActivity(new Intent(Intent.ACTION_VIEW, request.getUrl()))
+                            )
+                        )
+                        .create()
+                        .show();
+                    }
+
                     return true; //Deny URLs not on ALLOWLIST
                 }
                 for (String url : blockedURLs) {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -6,4 +6,6 @@
     <string name="error_no_gps">Veuillez activer le GPS</string>
     <string name="no_app_installed">Pas d\'application installée</string>
     <string name="intent_string">Ouvrir dans la webview restreinte</string>
+    <string name="title_open_link">Ouvrir le lien</string>
+    <string name="text_open_link">Ouvrir dans le navigateur externe ? %s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,6 @@
     <string name="text_location_permission">Please grant location permission and press button again.</string>
     <string name="error_no_gps">Please activate GPS</string>
     <string name="no_app_installed">No app installed</string>
+    <string name="title_open_link">Open link</string>
+    <string name="text_open_link">Open in external browser? %s</string>
 </resources>


### PR DESCRIPTION
With this change, when clicking on a link, such as the website of a place, a dialog opens and asks the user if they want to open the link in their external browser