### PR TITLE
Catch ActivityNotFoundException around outbound startActivity calls

### DIFF
--- a/app/src/main/java/us/spotco/maps/MainActivity.java
+++ b/app/src/main/java/us/spotco/maps/MainActivity.java
@@ -224,7 +224,11 @@ public class MainActivity extends Activity {
                 }
                 if (request.getUrl().toString().startsWith("tel:")) {
                     Intent dial = new Intent(Intent.ACTION_DIAL, request.getUrl());
-                    startActivity(dial);
+                    try {
+                        startActivity(dial);
+                    } catch (ActivityNotFoundException e) {
+                        Toast.makeText(context, R.string.no_app_installed, Toast.LENGTH_SHORT).show();
+                    }
                     return true;
                 }
                 if (!request.getUrl().toString().startsWith("https://")) {
@@ -246,8 +250,13 @@ public class MainActivity extends Activity {
                             .setNegativeButton(android.R.string.cancel, null)
                             .setPositiveButton(
                                     android.R.string.ok,
-                                    (dialogInterface, i) ->
-                                            startActivity(new Intent(Intent.ACTION_VIEW, request.getUrl()))
+                                    (dialogInterface, i) -> {
+                                        try {
+                                            startActivity(new Intent(Intent.ACTION_VIEW, request.getUrl()));
+                                        } catch (ActivityNotFoundException e) {
+                                            Toast.makeText(context, R.string.no_app_installed, Toast.LENGTH_SHORT).show();
+                                        }
+                                    }
                             )
                             .create()
                             .show();
@@ -279,8 +288,13 @@ public class MainActivity extends Activity {
                             .setNegativeButton(android.R.string.cancel, null)
                             .setPositiveButton(
                                 android.R.string.ok,
-                                (dialogInterface, i) ->
-                                    startActivity(new Intent(Intent.ACTION_VIEW, request.getUrl()))
+                                (dialogInterface, i) -> {
+                                    try {
+                                        startActivity(new Intent(Intent.ACTION_VIEW, request.getUrl()));
+                                    } catch (ActivityNotFoundException e) {
+                                        Toast.makeText(context, R.string.no_app_installed, Toast.LENGTH_SHORT).show();
+                                    }
+                                }
                             )
                             .create()
                             .show();


### PR DESCRIPTION
Closes #57.

### What changes

Three `startActivity(...)` calls inside `shouldOverrideUrlLoading` in `MainActivity.java` previously assumed the system could always resolve the intent:

1. `Intent.ACTION_DIAL` for `tel:` links (around line 227).
2. `Intent.ACTION_VIEW` for the `http://` confirmation dialog (around line 250).
3. `Intent.ACTION_VIEW` for the off-allowlist `https://` confirmation dialog (around line 283).

If no installed app can handle the intent, `startActivity(...)` raises `ActivityNotFoundException` and the activity crashes. Now each call is wrapped in a `try / catch (ActivityNotFoundException)` and the catch block shows the existing `R.string.no_app_installed` string as a short `Toast`.

`ActivityNotFoundException` is already imported in this file, so no new imports are needed.

```diff
 if (request.getUrl().toString().startsWith("tel:")) {
     Intent dial = new Intent(Intent.ACTION_DIAL, request.getUrl());
-    startActivity(dial);
+    try {
+        startActivity(dial);
+    } catch (ActivityNotFoundException e) {
+        Toast.makeText(context, R.string.no_app_installed, Toast.LENGTH_SHORT).show();
+    }
     return true;
 }
```

The two confirmation-dialog branches get the same treatment around their lambda bodies. Visible behaviour on the happy path is unchanged.
