### PR TITLE
fix: prevent "feedback" iframe to freeze the app

### DIFF
--- a/app/src/main/java/us/spotco/maps/MainActivity.java
+++ b/app/src/main/java/us/spotco/maps/MainActivity.java
@@ -341,6 +341,9 @@ public class MainActivity extends Activity {
                         "    }\n" +
                         "    #app {\n" +
                         "        top: 0 !important\n" +
+                        "    }\n" +
+                        "    #google-feedback, #google-feedback-submit-frame {\n" +
+                        "        display: none !important;\n" +
                         "    }`;\n" +
                         "    head[0].appendChild(style);\n" +
                         "}",null);


### PR DESCRIPTION
Fix #62 

`
  D  [shouldInterceptRequest][NOT ON ALLOWLIST] Blocked access to feedback-pa.clients6.google.com
`

Updated the CSS injection to hide the blocked iframe.
